### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @toreJohnsen
+/.security/ @toreJohnsen

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: IT
 product: Standardisering
 repo_types: [Documentation]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,29 +9,3 @@ spec:
   type: "documentation"
   lifecycle: "production"
   owner: "standardisering"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_sosi-utplukk-fra-generell-objektkatalog"
-  title: "Security Champion sosi-utplukk-fra-generell-objektkatalog"
-spec:
-  type: "security_champion"
-  parent: "it_security_champions"
-  members:
-  - "toreJohnsen"
-  children:
-  - "resource:sosi-utplukk-fra-generell-objektkatalog"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "sosi-utplukk-fra-generell-objektkatalog"
-  links:
-  - url: "https://github.com/kartverket/sosi-utplukk-fra-generell-objektkatalog"
-    title: "sosi-utplukk-fra-generell-objektkatalog på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_sosi-utplukk-fra-generell-objektkatalog"
-  dependencyOf:
-  - "component:sosi-utplukk-fra-generell-objektkatalog"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml